### PR TITLE
Add support for responsive images

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const VLazyImageComponent = {
       return this.intersected ? this.src : this.srcPlaceholder;
     },
     srcsetImage() {
-      return this.intersected && "srcset" in this ? this.srcset : false;
+      return this.intersected && this.srcset ? this.srcset : false;
     }
   },
   render(h) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,17 +7,23 @@ const VLazyImageComponent = {
     srcPlaceholder: {
       type: String,
       default: ""
+    },
+    srcset: {
+      type: String
     }
   },
   data: () => ({ observer: null, intersected: false, loaded: false }),
   computed: {
     srcImage() {
       return this.intersected ? this.src : this.srcPlaceholder;
+    },
+    srcsetImage() {
+      return this.intersected && "srcset" in this ? this.srcset : false;
     }
   },
   render(h) {
     return h("img", {
-      attrs: { src: this.srcImage },
+      attrs: { src: this.srcImage, srcset: this.srcsetImage },
       class: {
         "v-lazy-image": true,
         "v-lazy-image-loaded": this.loaded


### PR DESCRIPTION
Closes #9 

I've added the `srcset` prop to enable reponsive images. `srcset` can't be a simple attr as `alt`, `title` or `sizes` because when an `srcset` attr is present in an `<img>` tag the browser downloads automatically the images defined. So with this change the `srcset` attr will only be rendered if the image has been intersected.

I will create a simple demo in the following days to show it working, but I've already tested and is fully functional.

Hope it helps!