### PR TITLE
"load" event: Handle srcset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ const VLazyImageComponent = {
   },
   mounted() {
     this.$el.addEventListener("load", ev => {
-      if (this.$el.getAttribute('src') === this.src) {
+      if (this.$el.getAttribute('src') !== this.srcPlaceholder) {
         this.loaded = true;
         this.$emit("load");
       }


### PR DESCRIPTION
Currently, when using srcset, the loaded src is not necessarily the assigned src value (since multiple possible sources are defined with srcset).
Therefore, the if-condition in the load event can fail if using srcset. This causes the "load" event to never fire and never adds the v-lazy-image-loaded class.

This commit fixes the issue by inverting the logic: The image was loaded successfully if the src attribute doesn't equal the placeholder anymore.