### PR TITLE
[FIX] Use vue event instead of addEventListener to fix ssr bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "scripts": {
     "build": "rollit",
-    "install": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "v-lazy-image",
+  "name": "v-lazy-image-ssr",
   "version": "1.2.2",
   "description": "A Vue.js component to lazy load images using the Intersection Observer",
   "main": "dist/v-lazy-image.cjs.js",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "v-lazy-image-ssr",
   "version": "1.2.2",
   "description": "A Vue.js component to lazy load images using the Intersection Observer",
-  "main": "dist/v-lazy-image.cjs.js",
-  "module": "dist/v-lazy-image.es.js",
-  "unpkg": "dist/v-lazy-image.js",
-  "browser": "dist/v-lazy-image.js",
+  "main": "dist/v-lazy-image-ssr.cjs.js",
+  "module": "dist/v-lazy-image-ssr.es.js",
+  "unpkg": "dist/v-lazy-image-ssr.js",
+  "browser": "dist/v-lazy-image-ssr.js",
   "author": {
     "name": "Alex Jover Morales",
     "email": "alexjovermorales@gmail.com"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "rollit",
+    "install": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -31,27 +31,27 @@ const VLazyImageComponent = {
       class: {
         "v-lazy-image": true,
         "v-lazy-image-loaded": this.loaded
+      },
+      on: {
+        load: () => {
+          if (this.$el.getAttribute('src') !== this.srcPlaceholder) {
+            this.loaded = true;
+            this.$emit("load");
+          }
+
+          this.observer = new IntersectionObserver(entries => {
+            const image = entries[0];
+            if (image.isIntersecting) {
+              this.intersected = true;
+              this.observer.disconnect();
+              this.$emit("intersect");
+            }
+          }, this.intersectionOptions);
+
+          this.observer.observe(this.$el);
+        }
       }
     });
-  },
-  mounted() {
-    this.$el.addEventListener("load", ev => {
-      if (this.$el.getAttribute('src') !== this.srcPlaceholder) {
-        this.loaded = true;
-        this.$emit("load");
-      }
-    });
-
-    this.observer = new IntersectionObserver(entries => {
-      const image = entries[0];
-      if (image.isIntersecting) {
-        this.intersected = true;
-        this.observer.disconnect();
-        this.$emit("intersect");
-      }
-    }, this.intersectionOptions);
-
-    this.observer.observe(this.$el);
   },
   destroyed() {
     this.observer.disconnect();


### PR DESCRIPTION
Hi,
I had an issue when using SSR.
Element in a <no-ssr> component would always display the placeholder.
The problem came from a race condition where ```this.$el.getAttribute('src') !== this.srcPlaceholder``` would always be equal when the load event is called. 
So instead of adding a js event, i used the vue method inside the render function which solved the issue.