### PR TITLE
Fix: Dynamic image & Feat: Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ When the `src` image is loaded, a `v-lazy-image-loaded` class is added, so you c
   <v-lazy-image
     src="https://cdn-images-1.medium.com/max/1600/1*xjGrvQSXvj72W4zD6IWzfg.jpeg"
     src-placeholder="https://cdn-images-1.medium.com/max/80/1*xjGrvQSXvj72W4zD6IWzfg.jpeg"
-    />
+  />
 </template>
 
 <style scoped>
@@ -79,6 +79,14 @@ When the `src` image is loaded, a `v-lazy-image-loaded` class is added, so you c
 </style>
 ```
 
+In case you are using Webpack bundler for images too (just like Vue-cli):
+```html
+<v-lazy-image
+  src="https://cdn-images-1.medium.com/max/1600/1*xjGrvQSXvj72W4zD6IWzfg.jpeg"
+  :src-placeholder="require('../assets/img.jpg')"
+/>
+```
+
 You could listen to the `intersect` and `load` events for more complex animations and state handling:
 
 ```html
@@ -88,7 +96,7 @@ You could listen to the `intersect` and `load` events for more complex animation
     src-placeholder="https://cdn-images-1.medium.com/max/80/1*xjGrvQSXvj72W4zD6IWzfg.jpeg"
     @intersect="..."
     @load="..."
-    />
+  />
 </template>
 ```
 
@@ -102,7 +110,7 @@ Using the `srcset` property you can set images for different resolutions:
 <template>
   <v-lazy-image
     srcset="image.jpg 1x, image_2x.jpg 2x"
-    />
+  />
 </template>
 ```
 
@@ -140,7 +148,7 @@ Renders as:
 ```html
 <picture>
   <source srcset="image-320w.jpg 320w, image-480w.jpg 480w" />
-  <img srcset="image-320w.jpg 320w, image-480w.jpg 480w" alt="Fallback"/>
+  <img srcset="image-320w.jpg 320w, image-480w.jpg 480w" alt="Fallback" />
 </picture>
 ```
 
@@ -154,12 +162,13 @@ _Fields marked as (\*) are required._
 
 ### Props
 
-| Name                   | Type          | Description                                                                                                                                               |
-| ---------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src`                  | String _(\*)_ | Image `src` to lazy load when it intersects with the viewport                                                                                             |
-| `src-placeholder`      | String        | If defined, it will be shown until the `src` image is loaded. <br> Useful for progressive image loading, [see demo](https://codesandbox.io/s/9l3n6j5944)  |
-| `srcset`               | String        | Images to be used for different resolutions                                                                                                               |
-| `intersection-options` | Object        | The [Intersection Observer options object](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Creating_an_intersection_observer). |
+| Name                   | Type          | Default       | Description                                                                                                                                               |
+| ---------------------- | ------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src`                  | String _(\*)_ |       -       | Image `src` to lazy load when it intersects with the viewport                                                                                             |
+| `src-placeholder`      | String        | ' '           | If defined, it will be shown until the `src` image is loaded. <br> Useful for progressive image loading, [see demo](https://codesandbox.io/s/9l3n6j5944)  |
+| `srcset`               | String        |       -       | Images to be used for different resolutions                                                                                                               |
+| `intersection-options` | Object        | () => ({})    | The [Intersection Observer options object](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Creating_an_intersection_observer). |
+| `use-picture`          | Boolean       | false         | Wrap the img in a picture tag. |
 
 ### Events
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const VLazyImageComponent = {
   data: () => ({ observer: null, intersected: false, loaded: false }),
   computed: {
     srcImage() {
-      return this.intersected ? this.src : this.srcPlaceholder;
+      return this.intersected && this.src ? this.src : this.srcPlaceholder;
     },
     srcsetImage() {
       return this.intersected && this.srcset ? this.srcset : false;

--- a/src/index.js
+++ b/src/index.js
@@ -68,14 +68,12 @@ const VLazyImageComponent = {
         }
       }, this.intersectionOptions);
       this.observer.observe(this.$el);
-    } else {
-      console.error(
-        "v-lazy-image: this browser doesn't support IntersectionObserver. Please use this polyfill to make it work https://github.com/w3c/IntersectionObserver/tree/master/polyfill."
-      );
     }
   },
   destroyed() {
-    this.observer.disconnect();
+    if ("IntersectionObserver" in window) {
+      this.observer.disconnect();
+    }
   }
 };
 


### PR DESCRIPTION
- Fixed an issue where the component was taking the `src` instead of the `srcPlaceholder` when `intersected === true` and `src` is an empty string. This is for dynamic loading of images.

- Improved props section in readme.
- Improved progressive loading section in readme.

**Edit**: I was running tests on my project and 2 errors prompted:

1.- The `console.error: v-lazy-image: this browser doesn't support IntersectionObserver. Please use this polyfill to make it work https://github.com/w3c/IntersectionObserver/tree/master/polyfill.`.
2.- TypeError: Cannot read property 'disconnect' of null.

2nd is because in `destroyed()` is not checking if `IntersectionObserver` is in `window`.

1st is a bit about taste. There should be another way to show that but not while testing.

**Edit 2**: I just pushed a commit removing the console.error and fixing the bug at `destroyed()`.

The PR is ready to be merged but I think it should be introduced in a near future something like this https://github.com/Aljullu/react-lazy-load-image-component/blob/master/src/components/PlaceholderWithoutTracking.jsx `isPlaceholderInViewport()` to handle the position without `IntersectionObserver`.