### PR TITLE
Add type definitions for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.2",
   "description": "A Vue.js component to lazy load images using the Intersection Observer",
   "main": "dist/v-lazy-image.cjs.js",
+  "types": "src/index.d.ts",
   "module": "dist/v-lazy-image.es.js",
   "unpkg": "dist/v-lazy-image.js",
   "browser": "dist/v-lazy-image.es.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,25 @@
+import { Component, PluginObject, PropOptions } from 'vue';
+
+interface Data {
+  observer: IntersectionObserver | null;
+  intersected: boolean;
+  loaded: boolean;
+}
+interface Methods {
+  load: () => void;
+}
+interface Computed {
+  srcImage: () => string;
+  srcsetImage: () => string | boolean;
+}
+interface Props {
+  src: PropOptions<string>;
+  srcPlaceholder: PropOptions<string>;
+  srcset: PropOptions<string>;
+  intersectionOptions: PropOptions<IntersectionObserverInit>;
+  usePicture: PropOptions<boolean>;
+}
+declare const VLazyImageComponent: Component<Data, Methods, Computed, Props>;
+
+export default VLazyImageComponent;
+export const VLazyImagePlugin: PluginObject<any>;


### PR DESCRIPTION
To use your library in TypeScript, I wrote type definitions.

If you prefer providing this from `@types/*` package to including it in your repository, please tell me.