### PR TITLE
add image error event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,4 @@ _Fields marked as (\*) are required._
 | ----------- | -------------------------------------------------------- |
 | `intersect` | Triggered when the image intersects the viewport         |
 | `load`      | Triggered when the lazy image defined in `src` is loaded |
+| `error`     | Triggered when the lazy image defined in `src` fails to load |

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ const VLazyImageComponent = {
         this.loaded = true;
         this.$emit("load");
       }
+    },
+    error() {
+      this.$emit("error", this.$el)
     }
   },
   render(h) {
@@ -49,7 +52,7 @@ const VLazyImageComponent = {
         "v-lazy-image": true,
         "v-lazy-image-loaded": this.loaded
       },
-      on: { load: this.load }
+      on: { load: this.load, error: this.error }
     });
     if (this.usePicture) {
       return h(


### PR DESCRIPTION
This poll request adds the event handler error when the image fails to load, due a 404 for instance. This gives the chance to replace the failed image with a fallback image, or make any desired error handling.