### PR TITLE
Fix: //:0 is not valid html

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const VLazyImageComponent = {
     },
     srcPlaceholder: {
       type: String,
-      default: "//:0"
+      default: "data:,"
     },
     srcset: {
       type: String


### PR DESCRIPTION
The [accepted answer](https://stackoverflow.com/a/5775621) to “What’s the valid way to include an image with no src?” `//:0` - however, the W3C HTML validator doesn’t like the `src` value being `//:0`

![79729558-ecceec80-82ef-11ea-9b0f-65649ca5fec4](https://user-images.githubusercontent.com/787653/79765004-5d90fb80-8326-11ea-8157-3563e827897c.png)

https://stackoverflow.com/a/53365710 has a better answer: `"data:,"`- which is equivalent to `"data:text/plain,"` and validates:

![79729676-125bf600-82f0-11ea-86a3-a19cfebb4f95](https://user-images.githubusercontent.com/787653/79765102-7c8f8d80-8326-11ea-8c78-df0308776b81.png)
