### PR TITLE
Pass this.$el on load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const VLazyImageComponent = {
     load() {
       if (this.$el.getAttribute("src") !== this.srcPlaceholder) {
         this.loaded = true;
-        this.$emit("load");
+        this.$emit('load', this.$el);
       }
     },
     error() {


### PR DESCRIPTION
This PR fixes #69 . It passes `this.$el` to the `emit` event