### PR TITLE
Add note about fix for v2 import to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For **Vue 2**, import it from `v-lazy-image/v2`:
 
 ```js
 import VLazyImage from "v-lazy-image/v2";
+// in case of problems, replace with this: import VLazyImage from 'v-lazy-image/v2/v-lazy-image.es.js'
 
 export default {
   components: {


### PR DESCRIPTION
I got this error:
```
This dependency was not found:
* v-lazy-image/v2 in ./src/main.js
```

Took me a while to find this:
https://github.com/alexjoverm/v-lazy-image/issues/93#issuecomment-924761814

Thought a note in readme could save others the trouble