### PR TITLE
fix: getAttribute of null when remove root dom

### DIFF
--- a/v-lazy-image/index-v2.js
+++ b/v-lazy-image/index-v2.js
@@ -32,7 +32,7 @@ const VLazyImageComponent = {
   },
   methods: {
     load() {
-      if (this.$el.getAttribute("src") !== this.srcPlaceholder) {
+      if (this.$el?.getAttribute("src") !== this.srcPlaceholder) {
         this.loaded = true;
         this.$emit("load");
       }

--- a/v-lazy-image/index.js
+++ b/v-lazy-image/index.js
@@ -35,7 +35,7 @@ export default {
 
     // Methods
     const load = () => {
-      if (root.value.getAttribute("src") !== props.srcPlaceholder) {
+      if (root.value?.getAttribute("src") !== props.srcPlaceholder) {
         state.loaded = true;
         emit("load");
       }


### PR DESCRIPTION
It occurs inside dialog or something similar when remove the dom.

![image](https://user-images.githubusercontent.com/39915133/145944846-1cca325f-b367-441f-aed3-49f88f511836.png)
