### PR TITLE
Adds license to build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn.lock
 v-lazy-image/dist
 v-lazy-image/v2
 v-lazy-image/README.md
+v-lazy-image/LICENSE
 
 # Yarn
 # .yarn/*

--- a/v-lazy-image/package.json
+++ b/v-lazy-image/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "jest __tests__",
     "test:e2e": "cypress run-ct",
-    "prepublishOnly": "npm run build && cp ../README.md ./"
+    "prepublishOnly": "npm run build && cp ../README.md ./ && cp ../LICENSE ./"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
Howdy!

Thanks for the amazing work. One thing we noticed recently is that whilst the core package on GitHub has a LICENSE file, the compiled `v-lazy-image` distribution doesn't. This means that automated tooling that check the licenses of OSS packages for compliance can't pick up the MIT status of this package.

This PR adds the LICENSE in during the pre-publish step so that it will be included when downloaded from the package manager.

I really appreciate your hard work. Thanks for making OSS amazing!

Kind Regards,
Luke