### PR TITLE
Fix builds of VueJS 2 version in webpack@5

### DIFF
--- a/v-lazy-image/package.json
+++ b/v-lazy-image/package.json
@@ -34,6 +34,10 @@
     ".": {
       "import": "./dist/v-lazy-image.mjs",
       "require": "./dist/v-lazy-image.js"
+    },
+    "./v2": {
+      "import": "./v2/v-lazy-image.mjs",
+      "require": "./v2/v-lazy-image.js"
     }
   },
   "jest": {


### PR DESCRIPTION
I cannot use this library in our app running on Vue2 and built with webpack v5. The error that I get is:

> Module not found: Error: Package path ./v2 is not exported from package /Users/korya/dev/issue-webpack5-lazy-image/node_modules/v-lazy-image (see exports field in /Users/korya/dev/issue-webpack5-lazy-image/node_modules/v-lazy-image/package.json)

The proposed change fixes the problem.

I've created a minimal repo that demonstrates the problem https://github.com/korya/issue-webpack5-lazy-image/ and has some more details.

Also, this repo has 2 CI jobs defined (https://github.com/korya/issue-webpack5-lazy-image/actions/runs/2324999565):
- `build-as-is` that tries to build the project with the original `package.json` and fails
- `build-fixed` that tries to build the project with the updated `package.json` and succeeds

This PR should solve https://github.com/alexjoverm/v-lazy-image/issues/106