### PR TITLE
multiple entries where second is intersecting

### DIFF
--- a/v-lazy-image/index.js
+++ b/v-lazy-image/index.js
@@ -56,8 +56,7 @@ export default {
     onMounted(() => {
       if ("IntersectionObserver" in window) {
         state.observer = new IntersectionObserver((entries) => {
-          const image = entries[0];
-          if (image.isIntersecting) {
+          if (entries.some((entry) => entry.isIntersecting)) {
             state.intersected = true;
             state.observer.disconnect();
             emit("intersect");


### PR DESCRIPTION
Proposing a fix for issue #112 
Earlier the observer callback was only checking if the first entry is intersecting with the viewport but in some cases there can be multiple entries in the callback where the code only checks for the first one and if the first one is false and any other is true the code breaks.
Trying to check if any entry is intersecting is a viable solution to fix this.
Attaching a screen shot of the console reproducing the issue.
<img width="654" alt="Screenshot 2023-04-11 at 4 55 58 PM" src="https://user-images.githubusercontent.com/31899726/231148834-af851545-18ad-44a1-ab7d-fe042b53f486.png">
